### PR TITLE
 update libraries for yambo v5.2.0 installation

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,15 +3,19 @@
 export CPP="${CC} -E -P"
 export FPP="${FC} -E -P -cpp"
 ./configure \
-    --enable-openmp \
+    --enable-mpi --enable-openmp \
     --with-fft-path="${PREFIX}" \
-    --enable-hdf5-par-io \
     --with-hdf5-path="${PREFIX}" \
-    --with-netcdf-path="${PREFIX}"
-    #--enable-slepc-linalg \
-    #--with-slepc-path="${PREFIX}" \
-    #--with-petsc-path="${PREFIX}" \
-
+    --with-netcdf-path="${PREFIX}" \
+    --with-netcdff-path="${PREFIX}" \
+    --enable-hdf5-par-io \
+    --with-libxc-path="${PREFIX}" \
+    --with-scalapack-libs="${PREFIX}/lib/libscalapack.so" \
+    --with-blacs-libs="${PREFIX}/lib/libscalapack.so" \
+    --enable-par-linalg \
+    --with-slepc-path="${PREFIX}" \
+    --with-petsc-path="${PREFIX}" \
+    --enable-slepc-linalg 
 
 make -j$CPU_COUNT all
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: eb41e83df716eb87261cf130ffe7f930e7dc2e123343d47b73d5a3c69fea7316
 
 build:
-  number: 0
+  number: 1
   skip: true  # [not linux]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,23 +22,44 @@ requirements:
     - libgomp  # [linux]
     - llvm-openmp  # [osx]
     - wget
-  host:
     - openmpi
-    - fftw
     - libblas
     - liblapack
-    - hdf5 * *openmpi*
-    - libnetcdf * *openmpi*
-    - netcdf-fortran * *openmpi*
-    # re-enable after complex variants of libraries are available
-    # https://github.com/conda-forge/petsc-feedstock/issues/17
-    # - slepc
-    # - petsc
+    - fftw * *openmpi*
+    - hdf5 1.10 *openmpi*
+    - libnetcdf 4.7 *openmpi*
+    - netcdf-fortran 4.5 *openmpi*
+    - zlib
+    - scalapack
+    - libxc * *cpu*
+    - petsc * *complex*
+    - slepc * *complex*
+  host:
+    - openmpi
+    - libblas
+    - liblapack
+    - fftw * *openmpi*
+    - hdf5 1.10 *openmpi*
+    - libnetcdf 4.7 *openmpi*
+    - netcdf-fortran 4.5 *openmpi*
+    - zlib
+    - scalapack
+    - libxc * *cpu*
+    - petsc * *complex*
+    - slepc * *complex*
   run:
     - openmpi
     - fftw
     - zlib
     - libcurl
+    - scalapack
+    - libblas
+    - liblapack
+    - hdf5
+    - libnetcdf
+    - netcdf-fortran
+    - petsc
+    - slepc
 
 test:
   commands:


### PR DESCRIPTION
 - Solved an issue related to the recognition of the NetCDF library by the Yambo configure, specifying a previous version of the NetCDF library.
 - Added the support for libXC library.
 - Added the support for PETSc and SLEPc libraries.
 - Added the support for ScaLAPACK library.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
